### PR TITLE
Add a test for multiple require()-loaded files.

### DIFF
--- a/test/fixtures/error-multi-require-one.js
+++ b/test/fixtures/error-multi-require-one.js
@@ -1,0 +1,1 @@
+var inone = stuff

--- a/test/fixtures/error-multi-require-two.js
+++ b/test/fixtures/error-multi-require-two.js
@@ -1,0 +1,1 @@
+var intwo = stuff

--- a/test/fixtures/error-multi-require.js
+++ b/test/fixtures/error-multi-require.js
@@ -1,0 +1,3 @@
+var one = require('./error-multi-require-one.js')
+var two = require('./error-multi-require-two.js')
+var foo = stuff

--- a/test/formatter-multiple-require.js
+++ b/test/formatter-multiple-require.js
@@ -1,0 +1,57 @@
+var test = require("ava")
+var webpack = require("webpack")
+var conf = require("./utils/conf")
+var fs = require("fs")
+
+test.cb("eslint-loader can be configured to write multiple eslint result files",
+function(t) {
+  var outputFilename = "outputReport-[name].txt"
+  var outputFilenamesArr = [
+    "outputReport-error-multi-two.txt",
+    "outputReport-error-multi-one.txt",
+    "outputReport-error-multi-require.txt",
+  ]
+  var config = conf(
+    {
+      entry: "./test/fixtures/error-multi-require.js",
+    },
+    {
+      formatter: require("eslint/lib/formatters/checkstyle"),
+      outputReport: {
+        filePath: outputFilename,
+      },
+    }
+  )
+
+  /* Plan for the success count. Failure cases are going to fail anyway so the
+   * count being off for those cases doesn't matter. */
+  t.plan(outputFilenamesArr.length * 2)
+
+  webpack(config,
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    for (var i = 0; i < outputFilenamesArr.length; i++) {
+      var filename = config.output.path + outputFilenamesArr[i]
+
+      try {
+        var contents = fs.readFileSync(filename, "utf8")
+        var statsend = stats.compilation.errors.length - 1
+
+        t.pass("File '" + filename + "' has been created")
+
+        /* With require() loading the compilation messages seem to push in
+         * reverse. */
+        t.is(stats.compilation.errors[statsend - i].message, contents,
+          "File '" + filename + "' Contents should equal output")
+      }
+      catch (e) {
+        t.fail("Expected file '" + filename + "' to have been created:" + e)
+      }
+    }
+
+    t.end()
+  })
+})


### PR DESCRIPTION
Currently not working for the webpack 1 tests and I'm not sure why.

This seems to work in actual usage but for some reason the test runner
setup isn't creating the secondary output files.

I assume I'm setting something up incorrectly in the programmatic
webpack configuration or something else like that but I can't see what
it is at the moment.